### PR TITLE
Add sample transactions in progress screen

### DIFF
--- a/app/src/main/java/sl/kacinz/onluanmer/domain/model/SampleData.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/domain/model/SampleData.kt
@@ -1,0 +1,21 @@
+package sl.kacinz.onluanmer.domain.model
+
+object SampleData {
+    val sampleGoal = Goal(
+        id = -1,
+        name = "Demo Car Goal",
+        targetAmount = 2000,
+        date = "30.06",
+        imageUri = "android.resource://xx.example.sample/drawable/ic_safe",
+        currentAmount = 1110
+    )
+
+    val sampleTransactions = listOf(
+        Transaction(goalId = sampleGoal.id, amount = 120, comment = "Deposit for new car", date = "19.06"),
+        Transaction(goalId = sampleGoal.id, amount = 220, comment = "Deposit for new car", date = "20.06"),
+        Transaction(goalId = sampleGoal.id, amount = 430, comment = "Deposit for new car", date = "21.06"),
+        Transaction(goalId = sampleGoal.id, amount = 220, comment = "Deposit for new car", date = "22.06"),
+        Transaction(goalId = sampleGoal.id, amount = 0, comment = "No deposit today", date = "23.06"),
+        Transaction(goalId = sampleGoal.id, amount = 120, comment = "Deposit for new car", date = "24.06")
+    )
+}

--- a/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/GoalDetailFragment.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/GoalDetailFragment.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.bumptech.glide.Glide
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
+import sl.kacinz.onluanmer.domain.model.SampleData
 import kotlinx.coroutines.launch
 import sl.kacinz.onluanmer.R
 import sl.kacinz.onluanmer.databinding.FragmentGoalDetailBinding
@@ -68,12 +69,18 @@ class GoalDetailFragment : Fragment() {
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.transactions(args.goal.id)
-                    .collectLatest { list ->
-                        transactions = list
-                        showingAll = false
-                        updateList()
-                    }
+                if (args.goal.id == SampleData.sampleGoal.id) {
+                    transactions = SampleData.sampleTransactions
+                    showingAll = false
+                    updateList()
+                } else {
+                    viewModel.transactions(args.goal.id)
+                        .collectLatest { list ->
+                            transactions = list
+                            showingAll = false
+                            updateList()
+                        }
+                }
             }
         }
 

--- a/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/GoalListFragment.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/GoalListFragment.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
+import sl.kacinz.onluanmer.domain.model.SampleData
 import sl.kacinz.onluanmer.R
 import sl.kacinz.onluanmer.databinding.FragmentGoalListBinding
 import sl.kacinz.onluanmer.domain.model.Goal
@@ -40,8 +41,10 @@ class GoalListFragment : Fragment() {
             findNavController().navigate(R.id.createGoalFragment)
         }
         viewLifecycleOwner.lifecycleScope.launchWhenStarted {
-            viewModel.goals.collectLatest {
-                adapter.submitList(it) }
+            viewModel.goals.collectLatest { goals ->
+                val updated = goals + SampleData.sampleGoal
+                adapter.submitList(updated)
+            }
         }
     }
 

--- a/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/ProgressFragment.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/ProgressFragment.kt
@@ -25,6 +25,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import sl.kacinz.onluanmer.R
 import sl.kacinz.onluanmer.databinding.FragmentProgressBinding
+import sl.kacinz.onluanmer.domain.model.SampleData
 import sl.kacinz.onluanmer.domain.model.Transaction
 import sl.kacinz.onluanmer.presentation.ui.fragments.viewmodels.ProgressViewModel
 import sl.kacinz.onluanmer.utils.TimeRange
@@ -70,9 +71,14 @@ class ProgressFragment : Fragment() {
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.transactions(args.goal.id).collect { list ->
-                    allTransactions = list
+                if (args.goal.id == SampleData.sampleGoal.id) {
+                    allTransactions = SampleData.sampleTransactions
                     updateForRange()
+                } else {
+                    viewModel.transactions(args.goal.id).collect { list ->
+                        allTransactions = list
+                        updateForRange()
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- display demo goal in list and load its transactions in detail fragment
- include demo transactions when viewing progress of the demo goal

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c7d55050832a9dd48b78c32db914